### PR TITLE
fix: provide --s3_region to mp4split if not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ docker run --rm \
   -e USP_LICENSE_KEY=<LICENSE_KEY> \
   -e AWS_ACCESS_KEY_ID=<AWS ACCESS KEY ID> \
   -e AWS_SECRET_ACCESS_KEY=<AWS SECRET ACCESS KEY> \
+  -e AWS_REGION=eu-north-1 \
   eyevinntechnology/s3-mp4split -o s3://<outputbucket>/file.ismv \
   http://my.site/video-file.mp4
 ```
@@ -22,6 +23,7 @@ docker run --rm \
   -e USP_LICENSE_KEY=<LICENSE_KEY> \
   -e AWS_ACCESS_KEY_ID=<AWS ACCESS KEY ID> \
   -e AWS_SECRET_ACCESS_KEY=<AWS SECRET ACCESS KEY> \
+  -e AWS_REGION=eu-north-1 \
   eyevinntechnology/s3-mp4split -o s3://<outputbucket>/manifest.ism \
   http://my.site/video-file.mp4 \
   http://my.site/audio-file.mp4 \
@@ -34,9 +36,11 @@ docker run --rm \
   -e USP_LICENSE_KEY=<LICENSE_KEY> \
   -e AWS_ACCESS_KEY_ID=<AWS ACCESS KEY ID> \
   -e AWS_SECRET_ACCESS_KEY=<AWS SECRET ACCESS KEY> \
+  -e AWS_REGION=eu-north-1 \
   eyevinntechnology/s3-mp4split 
   --s3_access_key=<S3 AWS ACCESS KEY ID> \
   --s3_secret_key=<S3 AWS SECRET ACCESS KEY> \
+  --s3_region=<S3 AWS REGION> \
   -o s3://<outputbucket>/manifest.ism \
   http://my.site/video-file.mp4 \
   http://my.site/audio-file.mp4 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,10 @@ usage()
 
 args=()
 s3_access_args=()
+s3_region_args=()
 aws_access_key_id=$AWS_ACCESS_KEY_ID
 aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+aws_region=$AWS_REGION
 credentials_uri=$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
 
 eval set -- "$@"
@@ -27,6 +29,9 @@ while [[ $# > 0 ]]; do
     -*s3_secret*)
       s3_access_args+=($1)
       ;;
+    -*s3_region*)
+      s3_region_args+=($1)
+      ;;
     *)
       args+=($1)
       ;;
@@ -40,6 +45,12 @@ if [ ${#s3_access_args[@]} == 0 ]; then
   fi
 fi
 
+if [ ${#s3_region_args[@]} == 0 ]; then
+  if [ ! -z "$aws_region" ]; then
+    s3_region_args+=(--s3_region=$aws_region)
+  fi
+fi
+
 if [ -z "$OUTPUT" ]; then
   usage
 fi
@@ -47,10 +58,11 @@ fi
 echo "Writing to $OUTPUT"
 echo "mp4split default aws_access_key_id: $aws_access_key_id"
 echo "mp4split default aws_secret_access_key: *****"
+echo "mp4split default aws_region: $aws_region"
 echo "mp4split args: ${args[*]}"
 echo "container credentials uri: $credentials_uri"
 
-UspLicenseKey=$USP_LICENSE_KEY mp4split -o stdout:.temp ${s3_access_args[*]} ${args[*]} | \
+UspLicenseKey=$USP_LICENSE_KEY mp4split -o stdout:.temp ${s3_access_args[*]} ${s3_region_args[*]} ${args[*]} | \
   AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=$credentials_uri aws s3 cp - $OUTPUT 
 if [[ $? > 0 ]]; then
   echo "mp4split failed, cleaning up"


### PR DESCRIPTION
If `--s3_region` is not provided as arguments to mp4split it will use the value from the environment variable `$AWS_REGION` as default